### PR TITLE
Colby/remove redirect method

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,27 @@
+name: Ruby
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Ruby ${{ matrix.ruby }}
+    strategy:
+      matrix:
+        ruby:
+          - 3.1
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+
+      - name: Run the default task
+        run: bundle exec rake

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,4 +24,4 @@ jobs:
           bundler-cache: true
 
       - name: Run the default task
-        run: bundle exec rake
+        run: bundle exec rspec

--- a/Gemfile
+++ b/Gemfile
@@ -4,8 +4,11 @@ gem "appraisal"
 
 group :test do
   gem "rspec", "~> 3.0"
-  gem "rake",  "~> 10.3"
+  gem "rake"
   gem "sqlite3", platform: :ruby
+  gem "bcrypt"
+  gem "railties"
+  gem "activerecord"
   gem "activerecord-jdbcsqlite3-adapter", platform: :jruby
   gem "pry"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source "https://rubygems.org"
 
+gemspec
+
 gem "appraisal"
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -49,8 +49,14 @@ GEM
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
+    mini_portile2 (2.8.0)
     minitest (5.16.3)
+    nokogiri (1.13.9)
+      mini_portile2 (~> 2.8.0)
+      racc (~> 1.4)
     nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.13.9-x86_64-linux)
       racc (~> 1.4)
     pry (0.14.1)
       coderay (~> 1.1)
@@ -85,7 +91,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.12.0)
     rspec-support (3.12.0)
+    sqlite3 (1.5.3)
+      mini_portile2 (~> 2.8.0)
     sqlite3 (1.5.3-arm64-darwin)
+    sqlite3 (1.5.3-x86_64-linux)
     thor (1.2.1)
     tzinfo (2.0.5)
       concurrent-ruby (~> 1.0)
@@ -93,6 +102,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-22
+  ruby
+  x86_64-linux
 
 DEPENDENCIES
   activerecord

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,45 +1,101 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    appraisal (2.1.0)
+    actionpack (7.0.4)
+      actionview (= 7.0.4)
+      activesupport (= 7.0.4)
+      rack (~> 2.0, >= 2.2.0)
+      rack-test (>= 0.6.3)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.0, >= 1.2.0)
+    actionview (7.0.4)
+      activesupport (= 7.0.4)
+      builder (~> 3.1)
+      erubi (~> 1.4)
+      rails-dom-testing (~> 2.0)
+      rails-html-sanitizer (~> 1.1, >= 1.2.0)
+    activemodel (7.0.4)
+      activesupport (= 7.0.4)
+    activerecord (7.0.4)
+      activemodel (= 7.0.4)
+      activesupport (= 7.0.4)
+    activesupport (7.0.4)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 1.6, < 2)
+      minitest (>= 5.1)
+      tzinfo (~> 2.0)
+    appraisal (2.4.1)
       bundler
       rake
       thor (>= 0.14.0)
-    coderay (1.1.1)
-    diff-lcs (1.2.5)
-    method_source (0.8.2)
-    pry (0.10.3)
-      coderay (~> 1.1.0)
-      method_source (~> 0.8.1)
-      slop (~> 3.4)
-    rake (10.5.0)
-    rspec (3.4.0)
-      rspec-core (~> 3.4.0)
-      rspec-expectations (~> 3.4.0)
-      rspec-mocks (~> 3.4.0)
-    rspec-core (3.4.4)
-      rspec-support (~> 3.4.0)
-    rspec-expectations (3.4.0)
+    bcrypt (3.1.18)
+    builder (3.2.4)
+    coderay (1.1.3)
+    concurrent-ruby (1.1.10)
+    crass (1.0.6)
+    diff-lcs (1.5.0)
+    erubi (1.11.0)
+    i18n (1.12.0)
+      concurrent-ruby (~> 1.0)
+    loofah (2.19.0)
+      crass (~> 1.0.2)
+      nokogiri (>= 1.5.9)
+    method_source (1.0.0)
+    minitest (5.16.3)
+    nokogiri (1.13.9-arm64-darwin)
+      racc (~> 1.4)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    racc (1.6.0)
+    rack (2.2.4)
+    rack-test (2.0.2)
+      rack (>= 1.3)
+    rails-dom-testing (2.0.3)
+      activesupport (>= 4.2.0)
+      nokogiri (>= 1.6)
+    rails-html-sanitizer (1.4.3)
+      loofah (~> 2.3)
+    railties (7.0.4)
+      actionpack (= 7.0.4)
+      activesupport (= 7.0.4)
+      method_source
+      rake (>= 12.2)
+      thor (~> 1.0)
+      zeitwerk (~> 2.5)
+    rake (13.0.6)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.0)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-mocks (3.4.1)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.0)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.4.0)
-    rspec-support (3.4.1)
-    slop (3.6.0)
-    sqlite3 (1.3.11)
-    thor (0.19.1)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
+    sqlite3 (1.5.3-arm64-darwin)
+    thor (1.2.1)
+    tzinfo (2.0.5)
+      concurrent-ruby (~> 1.0)
+    zeitwerk (2.6.1)
 
 PLATFORMS
-  ruby
+  arm64-darwin-22
 
 DEPENDENCIES
+  activerecord
   activerecord-jdbcsqlite3-adapter
   appraisal
+  bcrypt
   pry
-  rake (~> 10.3)
+  railties
+  rake
   rspec (~> 3.0)
   sqlite3
 
 BUNDLED WITH
-   1.11.2
+   2.3.23

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,3 +1,11 @@
+PATH
+  remote: .
+  specs:
+    authem (2.1.0)
+      activesupport (>= 4.0.4)
+      bcrypt (~> 3.1)
+      railties (>= 4.0)
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -90,6 +98,7 @@ DEPENDENCIES
   activerecord
   activerecord-jdbcsqlite3-adapter
   appraisal
+  authem!
   bcrypt
   pry
   railties

--- a/lib/authem/controller.rb
+++ b/lib/authem/controller.rb
@@ -20,11 +20,6 @@ module Authem
         role = options.fetch(:as){ self.class.authem_role_for(model) }
         public_send "clear_all_#{role}_sessions_for", model
       end
-
-      def redirect_back_or_to(url, options={})
-        url = session.delete(:return_to_url) || url
-        redirect_to url, options
-      end
     end
 
     module ClassMethods

--- a/spec/controller_spec.rb
+++ b/spec/controller_spec.rb
@@ -113,10 +113,6 @@ describe Authem::Controller do
       expect(controller).to respond_to(:user_signed_in?)
     end
 
-    it "has redirect_back_or_to method" do
-      expect(controller).to respond_to(:redirect_back_or_to)
-    end
-
     it "can clear all sessions using clear_all_sessions method" do
       expect(controller).to receive(:clear_all_user_sessions_for).with(user)
       controller.clear_all_sessions_for user
@@ -377,36 +373,13 @@ describe Authem::Controller do
     end
 
     it "allows to specify role with special :as option" do
-      expect(controller).to receive(:sign_in_customer).with(user, as: :customer)
+      expect(controller).to receive(:sign_in_customer).with(user, { as: :customer })
       controller.sign_in user, as: :customer
     end
 
     it "raises the error when sign out can't guess the model properly" do
       message = "Ambigous match for #{user.inspect}: user, customer"
       expect{ controller.sign_out user }.to raise_error(Authem::AmbigousRoleError, message)
-    end
-  end
-
-  context "redirect after authentication" do
-    let(:controller_klass){ Class.new(BaseController){ authem_for :user }}
-
-    context "with saved url" do
-      before{ session[:return_to_url] = :my_url }
-
-      it "redirects back to saved url if it's available" do
-        expect(controller).to receive(:redirect_to).with(:my_url, notice: "foo")
-        controller.redirect_back_or_to :root, notice: "foo"
-      end
-
-      it "removes values from session after successful redirect" do
-        expect(controller).to receive(:redirect_to).with(:my_url, {})
-        expect{ controller.redirect_back_or_to :root }.to change{ session[:return_to_url] }.from(:my_url).to(nil)
-      end
-    end
-
-    it "redirects to specified url if there is no saved value" do
-      expect(controller).to receive(:redirect_to).with(:root, notice: "foo")
-      controller.redirect_back_or_to :root, notice: "foo"
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "bundler/setup"
-require "rails"
+require "active_record"
 require "authem"
 
 Dir[File.expand_path("../support/**/*.rb", __FILE__)].each(&method(:require))

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -7,7 +7,7 @@ ActiveRecord::Base.establish_connection(
   database: ":memory:"
 )
 
-class CreateUsersMigration < ActiveRecord::Migration
+class CreateUsersMigration < ActiveRecord::Migration[7.0]
   def up
     create_table :users do |t|
       t.string :email
@@ -17,7 +17,7 @@ class CreateUsersMigration < ActiveRecord::Migration
   end
 end
 
-class CreateSessionsMigration < ActiveRecord::Migration
+class CreateSessionsMigration < ActiveRecord::Migration[7.0]
   def up
     create_table :authem_sessions do |t|
       t.string     :role,       null: false


### PR DESCRIPTION
This PR removes the `redirect_back_or_to` method as it clashes with the Rails method of the same name. This PR also fixes the test setup to allow RSpec to be run.


Test Results:

```
$ rspec
......................................................................

Finished in 7.35 seconds (files took 0.43036 seconds to load)
70 examples, 0 failures
```